### PR TITLE
feat: add Warp CLI agent integration

### DIFF
--- a/crates/executors/default_profiles.json
+++ b/crates/executors/default_profiles.json
@@ -64,6 +64,11 @@
           "force": true
         }
       }
+    },
+    "WARP_CLI": {
+      "DEFAULT": {
+        "WARP_CLI": {}
+      }
     }
   }
 }

--- a/crates/executors/src/executors/mod.rs
+++ b/crates/executors/src/executors/mod.rs
@@ -15,7 +15,7 @@ use utils::msg_store::MsgStore;
 use crate::{
     executors::{
         amp::Amp, claude::ClaudeCode, codex::Codex, cursor::Cursor, gemini::Gemini,
-        opencode::Opencode, qwen::QwenCode,
+        opencode::Opencode, qwen::QwenCode, warp_cli::WarpCli,
     },
     mcp_config::McpConfig,
 };
@@ -27,6 +27,7 @@ pub mod cursor;
 pub mod gemini;
 pub mod opencode;
 pub mod qwen;
+pub mod warp_cli;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -75,6 +76,7 @@ pub enum CodingAgent {
     Opencode,
     Cursor,
     QwenCode,
+    WarpCli,
 }
 
 impl CodingAgent {
@@ -138,7 +140,7 @@ impl CodingAgent {
             Self::ClaudeCode(_) => vec![BaseAgentCapability::RestoreCheckpoint],
             Self::Amp(_) => vec![BaseAgentCapability::RestoreCheckpoint],
             Self::Codex(_) => vec![BaseAgentCapability::RestoreCheckpoint],
-            Self::Gemini(_) | Self::Opencode(_) | Self::Cursor(_) | Self::QwenCode(_) => vec![],
+            Self::Gemini(_) | Self::Opencode(_) | Self::Cursor(_) | Self::QwenCode(_) | Self::WarpCli(_) => vec![],
         }
     }
 }

--- a/crates/executors/src/executors/warp_cli.rs
+++ b/crates/executors/src/executors/warp_cli.rs
@@ -1,0 +1,136 @@
+use std::{path::Path, process::Stdio, sync::Arc};
+
+use async_trait::async_trait;
+use command_group::{AsyncCommandGroup, AsyncGroupChild};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+use ts_rs::TS;
+use utils::{msg_store::MsgStore, shell::get_shell_command};
+
+use crate::{
+    command::{apply_overrides, CmdOverrides, CommandBuilder},
+    executors::{AppendPrompt, ExecutorError, StandardCodingAgentExecutor},
+    logs::{
+        stderr_processor::normalize_stderr_logs,
+        utils::EntryIndexProvider,
+        plain_text_processor::PlainTextLogProcessor,
+        NormalizedEntry,
+        NormalizedEntryType,
+    },
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS, JsonSchema)]
+pub struct WarpCli {
+    #[serde(default)]
+    pub append_prompt: AppendPrompt,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_servers: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_flags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binary: Option<String>,
+    #[serde(flatten)]
+    pub cmd: CmdOverrides,
+}
+
+impl WarpCli {
+    fn build_command_builder(&self) -> CommandBuilder {
+        let mut builder = CommandBuilder::new(self.binary.clone().unwrap_or_else(|| "warp".to_string()))
+            .params(["agent", "run"]);
+
+        if let Some(profile) = &self.profile {
+            builder = builder.extend_params(["--profile", profile]);
+        }
+
+        if !self.mcp_servers.is_empty() {
+            for server in &self.mcp_servers {
+                builder = builder.extend_params(["--mcp-server", server]);
+            }
+        }
+
+        if !self.extra_flags.is_empty() {
+            builder = builder.extend_params(self.extra_flags.clone());
+        }
+
+        apply_overrides(builder, &self.cmd)
+    }
+
+    fn shell_escape(s: &str) -> String {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+}
+
+#[async_trait]
+impl StandardCodingAgentExecutor for WarpCli {
+    async fn spawn(
+        &self,
+        current_dir: &Path,
+        prompt: &str,
+    ) -> Result<AsyncGroupChild, ExecutorError> {
+        let (shell_cmd, shell_arg) = get_shell_command();
+        let mut builder = self.build_command_builder();
+        let combined_prompt = self.append_prompt.combine_prompt(prompt);
+        builder = builder.extend_params([
+            "--prompt".to_string(),
+            Self::shell_escape(&combined_prompt),
+        ]);
+        let warp_command = builder.build_initial();
+
+        let mut command = Command::new(shell_cmd);
+        command
+            .kill_on_drop(true)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .current_dir(current_dir)
+            .arg(shell_arg)
+            .arg(&warp_command);
+
+        let child = command.group_spawn()?;
+        Ok(child)
+    }
+
+    async fn spawn_follow_up(
+        &self,
+        _current_dir: &Path,
+        _prompt: &str,
+        _session_id: &str,
+    ) -> Result<AsyncGroupChild, ExecutorError> {
+        Err(ExecutorError::FollowUpNotSupported(
+            "Warp CLI does not support follow-up sessions".to_string(),
+        ))
+    }
+
+    fn normalize_logs(&self, msg_store: Arc<MsgStore>, _worktree_path: &Path) {
+        let entry_index_provider = EntryIndexProvider::start_from(&msg_store);
+        normalize_stderr_logs(msg_store.clone(), entry_index_provider.clone());
+
+        tokio::spawn(async move {
+            use futures::StreamExt;
+            let mut stdout = msg_store.stdout_chunked_stream();
+            let mut processor = PlainTextLogProcessor::builder()
+                .normalized_entry_producer(Box::new(|content: String| NormalizedEntry {
+                    timestamp: None,
+                    entry_type: NormalizedEntryType::AssistantMessage,
+                    content,
+                    metadata: None,
+                }))
+                .index_provider(entry_index_provider)
+                .build();
+
+            while let Some(Ok(chunk)) = stdout.next().await {
+                for patch in processor.process(chunk) {
+                    msg_store.push_patch(patch);
+                }
+            }
+        });
+    }
+
+    fn default_mcp_config_path(&self) -> Option<std::path::PathBuf> {
+        None
+    }
+}
+

--- a/crates/server/src/bin/generate_types.rs
+++ b/crates/server/src/bin/generate_types.rs
@@ -76,6 +76,7 @@ fn generate_types_content() -> String {
         executors::executors::cursor::Cursor::decl(),
         executors::executors::opencode::Opencode::decl(),
         executors::executors::qwen::QwenCode::decl(),
+        executors::executors::warp_cli::WarpCli::decl(),
         executors::executors::AppendPrompt::decl(),
         executors::actions::coding_agent_initial::CodingAgentInitialRequest::decl(),
         executors::actions::coding_agent_follow_up::CodingAgentFollowUpRequest::decl(),
@@ -167,6 +168,7 @@ fn generate_schemas() -> Result<(), Box<dyn std::error::Error>> {
     write_schema::<executors::executors::cursor::Cursor>("cursor", schemas_dir)?;
     write_schema::<executors::executors::opencode::Opencode>("opencode", schemas_dir)?;
     write_schema::<executors::executors::qwen::QwenCode>("qwen_code", schemas_dir)?;
+    write_schema::<executors::executors::warp_cli::WarpCli>("warp_cli", schemas_dir)?;
 
     Ok(())
 }

--- a/docs/agents/warp-cli.md
+++ b/docs/agents/warp-cli.md
@@ -1,0 +1,28 @@
+## Warp CLI
+
+This agent runs Warp's terminal-based AI workflows using the official CLI (`warp agent run`).
+
+### Requirements
+
+- Warp desktop app with CLI support enabled
+- Installed CLI (from Warp → Command Palette → "Install CLI")
+- Authenticated agent profiles and configured MCP servers
+
+### Config Fields
+
+| Field | Description |
+| --- | --- |
+| `profile` | Agent profile to use (`--profile`) |
+| `mcp_servers` | List of MCP servers (`--mcp-server`) |
+| `extra_flags` | Any additional flags (e.g. `--gui`) |
+| `binary` | Override binary (`warp-preview`, etc.) |
+
+### How it works
+
+Vibe Kanban shells out to:
+
+```bash
+warp agent run --prompt "<your prompt>" [--profile <id>] [--mcp-server <id>]...
+```
+
+Warp CLI streams output back into the Vibe Kanban interface in real time.

--- a/frontend/src/components/ExecutorConfigForm.tsx
+++ b/frontend/src/components/ExecutorConfigForm.tsx
@@ -17,7 +17,8 @@ type ExecutorType =
   | 'CODEX'
   | 'CURSOR'
   | 'OPENCODE'
-  | 'QWEN_CODE';
+  | 'QWEN_CODE'
+  | 'WARP_CLI';
 
 interface ExecutorConfigFormProps {
   executor: ExecutorType;

--- a/shared/schemas/warp_cli.json
+++ b/shared/schemas/warp_cli.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "append_prompt": {
+      "title": "Append Prompt",
+      "description": "Extra text appended to the prompt",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "textarea",
+      "default": null
+    },
+    "profile": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "mcp_servers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "extra_flags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "binary": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "base_command_override": {
+      "title": "Base Command Override",
+      "description": "Override the base command with a custom command",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "additional_params": {
+      "title": "Additional Parameters",
+      "description": "Additional parameters to append to the base command",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "type": "object"
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -34,9 +34,9 @@ export type ScriptRequest = { script: string, language: ScriptRequestLanguage, c
 
 export type ScriptRequestLanguage = "Bash";
 
-export enum BaseCodingAgent { CLAUDE_CODE = "CLAUDE_CODE", AMP = "AMP", GEMINI = "GEMINI", CODEX = "CODEX", OPENCODE = "OPENCODE", CURSOR = "CURSOR", QWEN_CODE = "QWEN_CODE" }
+export enum BaseCodingAgent { CLAUDE_CODE = "CLAUDE_CODE", AMP = "AMP", GEMINI = "GEMINI", CODEX = "CODEX", OPENCODE = "OPENCODE", CURSOR = "CURSOR", QWEN_CODE = "QWEN_CODE", WARP_CLI = "WARP_CLI" }
 
-export type CodingAgent = { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR": Cursor } | { "QWEN_CODE": QwenCode };
+export type CodingAgent = { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR": Cursor } | { "QWEN_CODE": QwenCode } | { "WARP_CLI": WarpCli };
 
 export type TaskTemplate = { id: string, project_id: string | null, title: string, description: string | null, template_name: string, created_at: string, updated_at: string, };
 
@@ -132,7 +132,7 @@ executor: BaseCodingAgent,
  */
 variant: string | null, };
 
-export type ExecutorConfig = { [key in string]?: { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR": Cursor } | { "QWEN_CODE": QwenCode } };
+export type ExecutorConfig = { [key in string]?: { "CLAUDE_CODE": ClaudeCode } | { "AMP": Amp } | { "GEMINI": Gemini } | { "CODEX": Codex } | { "OPENCODE": Opencode } | { "CURSOR": Cursor } | { "QWEN_CODE": QwenCode } | { "WARP_CLI": WarpCli } };
 
 export type BaseAgentCapability = "RESTORE_CHECKPOINT";
 
@@ -155,6 +155,8 @@ export type Cursor = { append_prompt: AppendPrompt, force?: boolean | null, mode
 export type Opencode = { append_prompt: AppendPrompt, model?: string | null, agent?: string | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
 
 export type QwenCode = { append_prompt: AppendPrompt, yolo?: boolean | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
+
+export type WarpCli = { append_prompt: AppendPrompt, profile?: string | null, mcp_servers?: Array<string>, extra_flags?: Array<string>, binary?: string | null, base_command_override?: string | null, additional_params?: Array<string> | null, };
 
 export type AppendPrompt = string | null;
 


### PR DESCRIPTION
## Summary
- add Warp CLI executor for running `warp agent run`
- register Warp CLI in agent catalog and default profiles
- document Warp CLI usage and expose config in settings

## Testing
- `npm run generate-types`
- `npm run check`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68bdf24e99a88327b36ae9e57a8c7456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Warp CLI executor for running agents via Warp.
  - Real-time output streaming into the interface.
  - Configurable options: profile, MCP servers, extra flags, binary, command overrides, additional parameters.
  - Default profile and configuration schema included; UI now accepts WARP_CLI in executor settings.

- Documentation
  - New Warp CLI agent guide with requirements, configuration details, and usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->